### PR TITLE
Add a live test-count badge for the SciATH suite

### DIFF
--- a/.github/workflows/publish-test-badges.yml
+++ b/.github/workflows/publish-test-badges.yml
@@ -15,29 +15,22 @@ on:
       - '.github/workflows/publish-test-badges.yml'
   workflow_dispatch:
 
+# Least privilege by default: every job runs read-only unless it raises its
+# own grant. Only the publish job, which writes the badges branch, asks for
+# contents: write, so a pull-request run never holds write access to the repo.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: badges-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  refresh-badges:
+  regenerate:
     name: Regenerate tests-total.json
     runs-on: ubuntu-latest
 
     steps:
-      - name: Guard against publishing from a non-main ref
-        # A manual dispatch can be launched from any branch. Publishing another
-        # ref's test count to the public badge would be misleading, so refuse
-        # it loudly. Pull-request runs skip this guard: they only regenerate
-        # and validate the badge, they never publish.
-        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
-        run: |
-          echo "Badges may only be published from main; this run is on ${{ github.ref }}." >&2
-          exit 1
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -59,33 +52,15 @@ jobs:
         # after it reaches main.
         run: python tools/generate_test_badges.py --out badge_payload/
 
-      - name: Publish badges to the badges branch
-        # The main ruleset requires a reviewed pull request for every change,
-        # so the badge JSON cannot be committed back onto main from CI.
-        # It is published instead to a dedicated badges branch that lives
-        # outside that ruleset; shields.io reads the JSON from that branch's
-        # raw URL. The branch carries only the badge file plus a README;
-        # consumers that need the source tree use main. The commit is marked
-        # [skip ci], and the branch never triggers CI (the test workflow runs
-        # on main and on pull requests only), so a refresh never starts a run.
-        # Pull-request runs stop at the regenerate step above and never reach
-        # this publish step.
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate the badge JSON
+        # Fail the check on a malformed file or a non-positive count so a
+        # generator regression never reaches main behind a green check. These
+        # are the exact bytes that get published: the publish job pushes this
+        # artifact as-is, and the same-run artifact download is integrity
+        # checked, so there is nothing left to re-validate on that side.
         run: |
           set -euo pipefail
-
-          payload="${GITHUB_WORKSPACE}/badge_payload"
-          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          branch="badges"
-
-          # Refuse to publish a partial or malformed set: a generator
-          # regression that drops the file or emits invalid JSON would
-          # otherwise leave a badge silently stale or broken behind a green
-          # check. Validate the file and its shields schema before touching
-          # the remote.
-          python3 - "${payload}" <<'PY'
+          python3 - badge_payload <<'PY'
           import json
           import sys
           from pathlib import Path
@@ -97,10 +72,68 @@ jobs:
               if not path.is_file():
                   sys.exit(f'Missing badge file: {path}')
               data = json.loads(path.read_text())
-              if data.get('schemaVersion') != 1 or not str(data.get('message', '')).strip():
+              message = str(data.get('message', '')).strip()
+              # A well-formed miscount is the failure the count badge is most
+              # exposed to, so require a positive integer, not merely a
+              # non-empty string.
+              if data.get('schemaVersion') != 1 or not message.isdigit() or int(message) < 1:
                   sys.exit(f'Malformed badge file: {path}')
           print(f'Validated {len(expected)} badge file(s).')
           PY
+
+      - name: Upload badge payload
+        # Hand the validated file to the publish job unchanged, so the bytes
+        # that reach the badges branch are exactly the ones checked here.
+        uses: actions/upload-artifact@v4
+        with:
+          name: badge-payload
+          path: badge_payload/tests-total.json
+          retention-days: 1
+          if-no-files-found: error
+
+  publish:
+    name: Publish to the badges branch
+    needs: regenerate
+    # Pull-request runs stop after regenerate: they validate the badge but
+    # never publish, so the write grant below is never exercised on a PR.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Guard against publishing from a non-main ref
+        # A manual dispatch can be launched from any branch. Publishing another
+        # ref's test count to the public badge would be misleading, so refuse
+        # it loudly before anything is written.
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "Badges may only be published from main; this run is on ${{ github.ref }}." >&2
+          exit 1
+
+      - name: Download badge payload
+        uses: actions/download-artifact@v4
+        with:
+          name: badge-payload
+          path: badge_payload
+
+      - name: Publish badges to the badges branch
+        # The main ruleset requires a reviewed pull request for every change,
+        # so the badge JSON cannot be committed back onto main from CI.
+        # It is published instead to a dedicated badges branch that lives
+        # outside that ruleset; shields.io reads the JSON from that branch's
+        # raw URL. The branch carries only the badge file plus a README;
+        # consumers that need the source tree use main. The commit is marked
+        # [skip ci], and the branch never triggers CI (the test workflow runs
+        # on main and on pull requests only), so a refresh never starts a run.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          payload="${GITHUB_WORKSPACE}/badge_payload"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          branch="badges"
 
           # Each fallible step returns explicitly: the function is invoked
           # from a conditional, which disables set -e inside it, so a failure

--- a/.github/workflows/publish-test-badges.yml
+++ b/.github/workflows/publish-test-badges.yml
@@ -1,0 +1,175 @@
+name: Refresh test count badges
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tests/**'
+      - 'tools/generate_test_badges.py'
+      - '.github/workflows/publish-test-badges.yml'
+  pull_request:
+    paths:
+      - 'tests/**'
+      - 'tools/generate_test_badges.py'
+      - '.github/workflows/publish-test-badges.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: badges-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  refresh-badges:
+    name: Regenerate tests-total.json
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Guard against publishing from a non-main ref
+        # A manual dispatch can be launched from any branch. Publishing another
+        # ref's test count to the public badge would be misleading, so refuse
+        # it loudly. Pull-request runs skip this guard: they only regenerate
+        # and validate the badge, they never publish.
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "Badges may only be published from main; this run is on ${{ github.ref }}." >&2
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Clone SciATH
+        # tests.yml uses SciATH constructs that a general YAML parser rejects,
+        # so the count is read with SciATH's own tolerant parser, the same one
+        # the test job relies on. SciATH depends only on the standard library,
+        # so no further install is needed.
+        run: git clone --depth=1 https://github.com/sciath/sciath tests/sciath
+
+      - name: Regenerate badge JSON file
+        # Runs on every trigger, including pull requests, so a generator or
+        # test-definition regression fails the check before merge rather than
+        # after it reaches main.
+        run: python tools/generate_test_badges.py --out badge_payload/
+
+      - name: Publish badges to the badges branch
+        # The main ruleset requires a reviewed pull request for every change,
+        # so the badge JSON cannot be committed back onto main from CI.
+        # It is published instead to a dedicated badges branch that lives
+        # outside that ruleset; shields.io reads the JSON from that branch's
+        # raw URL. The branch carries only the badge file plus a README;
+        # consumers that need the source tree use main. The commit is marked
+        # [skip ci], and the branch never triggers CI (the test workflow runs
+        # on main and on pull requests only), so a refresh never starts a run.
+        # Pull-request runs stop at the regenerate step above and never reach
+        # this publish step.
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          payload="${GITHUB_WORKSPACE}/badge_payload"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          branch="badges"
+
+          # Refuse to publish a partial or malformed set: a generator
+          # regression that drops the file or emits invalid JSON would
+          # otherwise leave a badge silently stale or broken behind a green
+          # check. Validate the file and its shields schema before touching
+          # the remote.
+          python3 - "${payload}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = Path(sys.argv[1])
+          expected = ('tests-total.json',)
+          for name in expected:
+              path = payload / name
+              if not path.is_file():
+                  sys.exit(f'Missing badge file: {path}')
+              data = json.loads(path.read_text())
+              if data.get('schemaVersion') != 1 or not str(data.get('message', '')).strip():
+                  sys.exit(f'Malformed badge file: {path}')
+          print(f'Validated {len(expected)} badge file(s).')
+          PY
+
+          # Each fallible step returns explicitly: the function is invoked
+          # from a conditional, which disables set -e inside it, so a failure
+          # must be propagated by hand rather than relied on to abort.
+          # Returns 0 on a successful push or a no-op, 1 on a retryable failure.
+          attempt_publish() {
+            local work exists rc
+
+            # Tell "branch absent" (ls-remote exit 2) apart from an
+            # unreachable remote (network/auth, other non-zero), so a
+            # transient failure is retried instead of being mistaken for
+            # an empty branch and overwritten with a root commit.
+            if git ls-remote --exit-code --heads "${remote}" "${branch}" >/dev/null 2>&1; then
+              exists=1
+            else
+              rc=$?
+              if [ "${rc}" -eq 2 ]; then
+                exists=0
+              else
+                echo "Could not reach the remote to check ${branch} (rc=${rc})." >&2
+                return 1
+              fi
+            fi
+
+            work="$(mktemp -d)" || return 1
+            cd "${work}" || return 1
+            git init -q || return 1
+
+            if [ "${exists}" -eq 1 ]; then
+              git fetch -q "${remote}" "${branch}" || return 1
+              git checkout -q FETCH_HEAD || return 1
+              # Drop everything the branch carried so the new commit holds
+              # only the freshly generated files; a stale leftover would
+              # otherwise survive the checkout-and-overwrite.
+              git rm -rfq --ignore-unmatch . >/dev/null 2>&1 || return 1
+            fi
+
+            cp "${payload}"/tests-total.json . || return 1
+            printf '%s\n' \
+              '# Test count badges' \
+              '' \
+              'Machine-generated by the `Refresh test count badges` workflow that runs on `main`.' \
+              'The documentation pages read this JSON file via a shields.io endpoint badge.' \
+              'Do not edit or delete this branch by hand; the source lives on `main`.' \
+              > README.md || return 1
+            git add tests-total.json README.md || return 1
+
+            if [ "${exists}" -eq 1 ] && git diff --cached --quiet; then
+              echo "Badge count unchanged; nothing to publish."
+              return 0
+            fi
+
+            git -c user.name="actions" -c user.email="actions@github.com" \
+              commit -qm "Update test count badges [skip ci]" || return 1
+            git push -q "${remote}" "HEAD:refs/heads/${branch}" || return 1
+            echo "Published refreshed badges to the ${branch} branch."
+            return 0
+          }
+
+          # The concurrency group serialises runs on main, so a competing run
+          # cannot move the branch tip mid-push; the retry only covers a
+          # transient network or fetch hiccup. Each attempt re-checks the
+          # branch state from a clean working tree.
+          for attempt in 1 2 3; do
+            if attempt_publish; then
+              exit 0
+            fi
+            echo "Publish attempt ${attempt} failed; retrying."
+            sleep 2
+          done
+          echo "Failed to publish badges after 3 attempts." >&2
+          exit 1

--- a/docs/Explanations/testing.md
+++ b/docs/Explanations/testing.md
@@ -1,14 +1,16 @@
 # Testing suite
 
+[![Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/SPIDER/ci.yml?branch=main&label=Tests)](https://github.com/FormingWorlds/SPIDER/actions/workflows/ci.yml)
 [![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/SPIDER/badges/tests-total.json)](https://proteus-framework.org/testing)
 
 SPIDER's tests are integration cases run by the [SciATH](https://github.com/sciath/sciath) harness from `tests/tests.yml`.
 Each case drives the compiled `spider` binary and compares its output against expected values within set tolerances.
-The badge above shows how many cases the suite currently defines.
+The **Tests** badge reports whether the CI workflow, which builds SPIDER and runs the full suite on `main`, is passing; the **tests** badge shows how many cases the suite currently defines.
 For how to run the suite locally, see [Testing SPIDER](../How-to/test.md).
 
 ## Badge system
 
-The count is produced by `tools/generate_test_badges.py` and published as a shields.io endpoint JSON file on the repository's `badges` branch, refreshed on `main` whenever the test suite changes.
+The **Tests** badge is the status of the `CI` GitHub Actions workflow: it is green only when SPIDER builds against PETSc and every SciATH case passes on `main`.
+The case count is produced by `tools/generate_test_badges.py` and published as a shields.io endpoint JSON file on the repository's `badges` branch, refreshed on `main` whenever the test suite changes.
 The badge reads that file, so it shows the current case count.
 The same number appears on the central [PROTEUS testing dashboard](https://proteus-framework.org/testing).

--- a/docs/Explanations/testing.md
+++ b/docs/Explanations/testing.md
@@ -1,0 +1,14 @@
+# Testing suite
+
+[![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/SPIDER/badges/tests-total.json)](https://proteus-framework.org/testing)
+
+SPIDER's tests are integration cases run by the [SciATH](https://github.com/sciath/sciath) harness from `tests/tests.yml`.
+Each case drives the compiled `spider` binary and compares its output against expected values within set tolerances.
+The badge above shows how many cases the suite currently defines.
+For how to run the suite locally, see [Testing SPIDER](../How-to/test.md).
+
+## Badge system
+
+The count is produced by `tools/generate_test_badges.py` and published as a shields.io endpoint JSON file on the repository's `badges` branch, refreshed on `main` whenever the test suite changes.
+The badge reads that file, so it shows the current case count.
+The same number appears on the central [PROTEUS testing dashboard](https://proteus-framework.org/testing).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - First run: Tutorials/first_run.md
 
   - Explanations:
+      - Testing suite: Explanations/testing.md
       - Model overview:
         - Thermodynamics: Explanations/basic_thermodynamics.md
         - Mass conservation and energy transport: Explanations/transport.md

--- a/tools/generate_test_badges.py
+++ b/tools/generate_test_badges.py
@@ -63,8 +63,14 @@ def _ensure_sciath_importable() -> None:
         import sciath  # noqa: F401
 
         return
-    except ImportError:
-        pass
+    except ModuleNotFoundError as exc:
+        # Fall back to the vendored clone only when the top-level ``sciath``
+        # package itself is absent, which is the CI case (SciATH is cloned into
+        # tests/sciath but not installed). Any other missing import, such as a
+        # dependency missing from inside a broken SciATH install, is a genuine
+        # fault and re-raises rather than being hidden behind the fallback.
+        if exc.name != "sciath":
+            raise
 
     vendored = _REPO_ROOT / "tests" / "sciath"
     if vendored.is_dir():

--- a/tools/generate_test_badges.py
+++ b/tools/generate_test_badges.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Generate a shields.io endpoint-badge JSON file for the SPIDER test count.
+
+SPIDER's test suite is a set of SciATH integration cases defined in
+``tests/tests.yml`` (each case drives the compiled C/PETSc ``spider`` binary
+and its Python post-processing, not pytest). This script counts those cases
+and writes a single shields.io endpoint-badge JSON file:
+
+    {"schemaVersion": 1, "label": "tests", "message": "<count>", "color": "blue"}
+
+The count is the number of entries in the ``tests:`` sequence of
+``tests/tests.yml``, which is one-to-one with the cases the SciATH harness
+builds and runs. ``tests/tests.yml`` is not standard YAML (SciATH allows
+constructs such as ``key: val:`` that a general YAML parser rejects), so the
+file is read with SciATH's own tolerant subset parser rather than PyYAML. The
+count therefore depends only on the case list in ``tests/tests.yml``, and a
+genuinely unparseable or empty file fails the run loudly instead of publishing
+a wrong or zero number.
+
+Usage
+-----
+    python tools/generate_test_badges.py --out badge_payload/
+
+The published copy lives on the ``badges`` branch, written there by the
+``Refresh test count badges`` workflow; nothing is committed into the source
+tree on ``main``. SciATH must be importable: the workflow clones it into
+``tests/sciath`` (mirroring the test job), and when run there this script adds
+that directory to the import path automatically. SciATH's parser depends only
+on the standard library, so no third-party install is needed to produce the
+count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_FILE = _REPO_ROOT / "tests" / "tests.yml"
+
+# Single-file public surface. SPIDER has no unit/integration split to expose,
+# so only the total count is published; faking sub-categories the suite does
+# not have would misrepresent it.
+_BADGE_NAME = "total"
+_BADGE_LABEL = "tests"
+
+
+def _ensure_sciath_importable() -> None:
+    """Make the ``sciath`` package importable, vendoring it if needed.
+
+    Prefers an already-installed or ``PYTHONPATH``-exposed SciATH. Falls back
+    to the ``tests/sciath`` clone that the CI test job and the badge workflow
+    create, so the same checkout works locally and in CI.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If SciATH is neither importable nor present at ``tests/sciath``.
+    """
+    try:
+        import sciath  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    vendored = _REPO_ROOT / "tests" / "sciath"
+    if vendored.is_dir():
+        sys.path.insert(0, str(vendored))
+        return
+
+    raise ModuleNotFoundError(
+        "SciATH is not importable and no clone was found at "
+        f"{vendored}. Clone it there (git clone --depth=1 "
+        "https://github.com/sciath/sciath tests/sciath) or add it to "
+        "PYTHONPATH before running this script."
+    )
+
+
+def count_sciath_tests(tests_file: Path) -> int:
+    """Return the number of SciATH cases defined in ``tests_file``.
+
+    Parameters
+    ----------
+    tests_file : Path
+        Path to the SciATH test-definition YAML (``tests/tests.yml``).
+
+    Returns
+    -------
+    int
+        Number of entries in the ``tests:`` sequence, i.e. the number of
+        cases the SciATH harness builds and runs.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``tests_file`` does not exist.
+    sciath.yaml_parse.SciATHYAMLParseException
+        If the file cannot be parsed. Propagated deliberately so a broken
+        definition fails the badge run rather than publishing a wrong number.
+    ValueError
+        If the parsed file has no ``tests:`` sequence, or the sequence is
+        empty. SPIDER always defines at least one case, so a zero count means
+        the definition or the parse degraded and must not be published.
+    """
+    if not tests_file.is_file():
+        raise FileNotFoundError(f"SciATH test definition not found: {tests_file}")
+
+    _ensure_sciath_importable()
+    from sciath import yaml_parse
+
+    data = yaml_parse.parse_yaml_subset_from_file(str(tests_file))
+    if not isinstance(data, dict) or not isinstance(data.get("tests"), list):
+        raise ValueError(f"{tests_file} must contain a 'tests:' sequence of cases.")
+
+    count = len(data["tests"])
+    if count == 0:
+        raise ValueError(
+            f"No SciATH cases found in {tests_file}; refusing to publish a zero count."
+        )
+    return count
+
+
+def write_badge(out_dir: Path, name: str, label: str, count: int) -> Path:
+    """Write a shields.io endpoint-badge JSON file.
+
+    Parameters
+    ----------
+    out_dir : Path
+        Directory to write the JSON file into. Created if absent.
+    name : str
+        Suffix used in the filename ``tests-<name>.json``.
+    label : str
+        Badge label rendered on the left side of the shield.
+    count : int
+        Badge message count rendered on the right side of the shield.
+
+    Returns
+    -------
+    Path
+        Path of the written JSON file.
+    """
+    payload = {
+        "schemaVersion": 1,
+        "label": label,
+        "message": str(count),
+        "color": "blue",
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"tests-{name}.json"
+    out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return out_path
+
+
+def main() -> int:
+    """Entry point.
+
+    Returns
+    -------
+    int
+        Process exit code (0 on success; failures raise).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Directory to write the tests-total.json badge file into.",
+    )
+    args = parser.parse_args()
+
+    count = count_sciath_tests(_TESTS_FILE)
+    write_badge(args.out, _BADGE_NAME, _BADGE_LABEL, count)
+    print(f"{_BADGE_LABEL}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this does

Adds a live test-count badge for SPIDER. SPIDER's tests are SciATH integration cases in `tests/tests.yml`, not pytest, so a small tool counts those cases and publishes a shields.io endpoint badge showing the current total.

## Why

The documentation and repo can now show at a glance how many tests the suite runs, and the number stays current automatically instead of being hand-maintained.

## Changes

- `tools/generate_test_badges.py`: counts the SciATH cases in `tests/tests.yml` and writes `tests-total.json` in the shields.io endpoint schema. It reads the case list with SciATH's own tolerant parser, because `tests.yml` uses constructs a general YAML parser rejects, and refuses an empty or missing case list rather than publishing a wrong or zero count.
- `.github/workflows/publish-test-badges.yml`: on pushes to `main` that touch the tests, the tool, or the workflow, it regenerates the badge and publishes it to a dedicated `badges` branch. It also regenerates the badge on pull requests as a check, without publishing.

The badge is published to a separate `badges` branch rather than committed onto `main` because `main` requires a reviewed pull request for every change, so CI cannot push to it. The `badges` branch carries only the badge JSON and a short README, and it never triggers CI.

## Testing

- Ran the generator against the current `tests/tests.yml`; it reports 4 cases and writes valid shields.io JSON.
- Exercised the guard paths: a missing file, an empty case list, and a malformed definition each fail loudly instead of publishing a number.
- Confirmed the workflow's embedded schema validator accepts the generated file, and that the YAML parses.
