### PR TITLE
Upload only the filtered coverage report to Codecov

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,5 +58,11 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml
+        # Upload only the gcovr-filtered report. Without these, the uploader
+        # searches the coverage build tree and runs gcov on every instrumented
+        # object (including the vendored cJSON.c and the tests/c executables
+        # that the coverage gate excludes), which halves the reported number.
+        disable_search: true
+        plugins: noop
         flags: nightly
         fail_ci_if_error: false


### PR DESCRIPTION
## What this does

Restricts the nightly Codecov upload to the gcovr-generated `coverage.xml` so the coverage badge matches the nightly gate.

## Why

The Codecov badge read 42% while the nightly coverage gate measured 81% line coverage on the same run. The uploader was searching the coverage build tree and running gcov on every instrumented object, including the vendored `cJSON.c` and the `tests/c` executables that the gate excludes, which diluted the number to about half.

## Changes

- Set `disable_search: true` and `plugins: noop` on the codecov-action step in `nightly.yml` so only the filtered `coverage.xml` is uploaded.

## Testing

- PR checks (build, unit + smoke, lint, structure, quality) are unaffected; this only changes the nightly's Codecov step. Verified by re-running the nightly on main after merge and confirming the badge reads the gcovr figure.