### PR TITLE
Halve the shared reaction run's mesh to clear the smoke ceiling

### DIFF
--- a/tests/test_reaction.py
+++ b/tests/test_reaction.py
@@ -32,11 +32,19 @@ def reaction_run(cached_spider_run):
     """One macro step of the Bower et al. (2021) reaction configuration.
 
     A single 1000-year step keeps the smoke budget while exercising the
-    full reaction, outgassing, and atmosphere coupling.
+    full reaction, outgassing, and atmosphere coupling. The mesh runs at
+    50 nodes instead of the configuration file's 100, matching the other
+    reaction-family fixtures and cutting the instrumented run from 18 to
+    7 seconds so it clears the smoke-tier timeout on slow runners. The
+    closure and conservation identities asserted on this run hold to
+    solver tolerance at any resolution; the sign structure follows from
+    the secular cooling of the step, and the magnitude guards hold at
+    both resolutions with more than twentyfold margin (the transfer
+    magnitudes themselves shift about two percent between meshes).
     """
     return cached_spider_run(
         opts_file='reaction.opts',
-        overrides=('-nstepsmacro', '1'),
+        overrides=('-nstepsmacro', '1', '-n', '50'),
         name='reaction_short',
     )
 
@@ -97,8 +105,8 @@ def test_reaction_transfer_balances_the_initial_inventory(reaction_run):
     for volatile in VOLATILES:
         r = _reservoirs(doc1, volatile)
         # rel 1e-5: the budget closes to the tolerance of the coupled
-        # volatile solve (observed residual 1.4e-6 on CO2 after one
-        # 1000-year step).
+        # volatile solve. CO2 is the worst species at 1.4e-6 after one
+        # 1000-year step; the other three close at 3e-8 or better.
         assert r['initial_kg'] == pytest.approx(
             r['physical_kg'] + r['reaction_kg'], rel=1e-5
         ), volatile


### PR DESCRIPTION
## What this does

Runs the shared one-step reaction fixture at 50 mesh nodes instead of the configuration file's 100, matching the other reaction-family fixtures.

## Why

The run sat at the edge of the 120-second smoke ceiling on slow coverage-instrumented runners and timed out on both post-merge runs on main, erroring its three dependent tests. At 50 nodes the instrumented run drops from 18 to 7 seconds on a development machine, which extrapolates to well under a minute on the slowest runner class.

## Changes

- tests/test_reaction.py: the reaction_run fixture adds a '-n 50' override; the docstring states which assertions are resolution-independent (the closure and conservation identities), which follow from the secular cooling of the step (the sign structure), and which hold by measured margin (the magnitude guards, more than twentyfold at both resolutions); the budget-residual comment now covers all four species.

## Testing

- All five tests in the file pass at 50 nodes; the per-species budget residuals are unchanged (CO2 worst at 1.4e-6 against the rel 1e-5 assertion, the others at 3e-8 or better; transfer magnitudes shift about two percent between meshes, far inside the twentyfold guard margins).
- Structure validator, test-quality lint, and ruff all pass.